### PR TITLE
修复popup的遮罩层默认值不生效的bug

### DIFF
--- a/packages/wxc-popup/src/index.wxc
+++ b/packages/wxc-popup/src/index.wxc
@@ -28,7 +28,10 @@ export default {
     }
   },
   data: {
-    maskStatus: this.status
+    maskStatus: 'hide'
+  },
+  ready() {
+    this.properties.status === 'show' && this.showMask()
   },
   methods: {
     showMask() {

--- a/packages/wxc-popup/src/index.wxc
+++ b/packages/wxc-popup/src/index.wxc
@@ -28,7 +28,7 @@ export default {
     }
   },
   data: {
-    maskStatus: 'hide'
+    maskStatus: this.status
   },
   methods: {
     showMask() {


### PR DESCRIPTION
status可以传递，但是maskStatus却没有同样传递进来