### PR TITLE
docs(loadmoreDoc):  默认icon加载中demo缺少icon参数修复

### DIFF
--- a/src/pages/loadmore/demos/demo-default-loading.wxc
+++ b/src/pages/loadmore/demos/demo-default-loading.wxc
@@ -1,5 +1,5 @@
 <template>
-  <wxc-loadmore></wxc-loadmore>
+  <wxc-loadmore icon="{{true}}"></wxc-loadmore>
 </template>
 
 <script>


### PR DESCRIPTION
还有官网上示例错误，麻烦修复一下

![image](https://user-images.githubusercontent.com/14267409/39392727-a747cdee-4aed-11e8-9ac7-8bebcd350c27.png)

![image](https://user-images.githubusercontent.com/14267409/39392729-ab553f84-4aed-11e8-8195-66f4f573fe84.png)
